### PR TITLE
better semantics?

### DIFF
--- a/layout/header.php
+++ b/layout/header.php
@@ -10,7 +10,7 @@
             </a></li>
 
         <!-- Divider -->
-        <li><hr class="sidebar-divider my-0"></li>
+        <li><hr class="sidebar-divider my-0" /></li>
 
         <!-- Nav Item - Dashboard -->
         <li class="nav-item active">

--- a/layout/header.php
+++ b/layout/header.php
@@ -5,12 +5,12 @@
     <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
 
         <!-- Sidebar - Brand -->
-        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="/LiturgicalCalendar">
-            <div class="sidebar-brand-text mx-3">Liturgical Calendar Project</sup></div>
-        </a>
+        <li><a class="sidebar-brand d-flex align-items-center justify-content-center" href="/LiturgicalCalendar">
+            <div class="sidebar-brand-text mx-3">Liturgical Calendar Project</div>
+            </a></li>
 
         <!-- Divider -->
-        <hr class="sidebar-divider my-0">
+        <li><hr class="sidebar-divider my-0"></li>
 
         <!-- Nav Item - Dashboard -->
         <li class="nav-item active">
@@ -20,12 +20,12 @@
         </li>
 
         <!-- Divider -->
-        <hr class="sidebar-divider">
+        <li><hr class="sidebar-divider"></li>
 
         <!-- Heading -->
-        <div class="sidebar-heading">
+        <li><div class="sidebar-heading">
             Scripts
-        </div>
+            </div></li>
 
         <li class="nav-item">
             <a class="nav-link" href="LitCalEngine.php">
@@ -46,12 +46,12 @@
         </li>
 
         <!-- Divider -->
-        <hr class="sidebar-divider">
+        <li><hr class="sidebar-divider"></li>
     
         <!-- Heading -->
-        <div class="sidebar-heading">
+        <li><div class="sidebar-heading">
             Examples
-        </div>
+            </div></li>
     
         <li class="nav-item">
             <a class="nav-link" href="examples/php/">
@@ -75,12 +75,12 @@
         </li>
 
         <!-- Divider -->
-        <hr class="sidebar-divider d-none d-md-block">
+        <li><hr class="sidebar-divider d-none d-md-block"></li>
 
         <!-- Sidebar Toggler (Sidebar) -->
-        <div class="text-center d-none d-md-inline">
+        <li><div class="text-center d-none d-md-inline">
             <button class="rounded-circle border-0" id="sidebarToggle"></button>
-        </div>
+            </div></li>
     </ul>
     <!-- End of Sidebar -->
 

--- a/layout/header.php
+++ b/layout/header.php
@@ -20,7 +20,7 @@
         </li>
 
         <!-- Divider -->
-        <li><hr class="sidebar-divider"></li>
+        <li><hr class="sidebar-divider" /></li>
 
         <!-- Heading -->
         <li><div class="sidebar-heading">
@@ -46,7 +46,7 @@
         </li>
 
         <!-- Divider -->
-        <li><hr class="sidebar-divider"></li>
+        <li><hr class="sidebar-divider" /></li>
     
         <!-- Heading -->
         <li><div class="sidebar-heading">
@@ -75,7 +75,7 @@
         </li>
 
         <!-- Divider -->
-        <li><hr class="sidebar-divider d-none d-md-block"></li>
+        <li><hr class="sidebar-divider d-none d-md-block" /></li>
 
         <!-- Sidebar Toggler (Sidebar) -->
         <li><div class="text-center d-none d-md-inline">


### PR DESCRIPTION
I believe direct children of `ul` elements should only be `li` elements? Fixing this by wrapping all `div`s and `a`nchor tags in `li` tags doesn't seem to affect the bootstrap theming, I think it's more semantically correct?